### PR TITLE
FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Open source tool and library for flashing Bouffalo RISC-V MCUs.
 - [x] Windows
 - [x] Linux
 - [x] Apple
+- [x] FreeBSD
 
 # Building
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you have not cloned this repository locally; clone the git repository locally
 ```bash
 git clone --recursive https://github.com/pine64/blisp.git
 cd blisp
+git submodule update --init --recursive
 ```
 
 ## Build the library and command line utility

--- a/lib/blisp.c
+++ b/lib/blisp.c
@@ -79,7 +79,7 @@ int32_t blisp_device_open(struct blisp_device* device, const char* port_name) {
   //  if (device->is_usb) {
   //    device->current_baud_rate = 2000000;
   //  } else {
-  device->current_baud_rate = 500000;
+  device->current_baud_rate = 460800;
   //  }
 
 #if 0

--- a/lib/blisp.c
+++ b/lib/blisp.c
@@ -73,7 +73,7 @@ int32_t blisp_device_open(struct blisp_device* device, const char* port_name) {
   sp_set_stopbits(serial_port, 1);
   sp_set_flowcontrol(serial_port, SP_FLOWCONTROL_NONE);
 
-  uint32_t vid, pid;
+  int vid, pid;
   sp_get_port_usb_vid_pid(serial_port, &vid, &pid);
   device->is_usb = pid == 0xFFFF;
   //  if (device->is_usb) {

--- a/lib/blisp_easy.c
+++ b/lib/blisp_easy.c
@@ -24,6 +24,8 @@ static int64_t blisp_easy_transport_size(struct blisp_easy_transport* transport)
     return transport->data.memory.data_size;
   } else {
     // TODO: Implement
+	  printf("%s() Warning: calling non-implemented function\n", __func__);
+	  return -1;
   }
 }
 

--- a/lib/blisp_easy.c
+++ b/lib/blisp_easy.c
@@ -331,7 +331,7 @@ int32_t blisp_easy_flash_write(struct blisp_device* device,
                                uint32_t data_size,
                                blisp_easy_progress_callback progress_callback) {
   int32_t ret;
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined (__FreeBSD__)
   const uint16_t buffer_max_size = 372 * 1;
 #else
   const uint16_t buffer_max_size = 2052;

--- a/tools/blisp/src/common.c
+++ b/tools/blisp/src/common.c
@@ -11,7 +11,7 @@
 #include "util.h"
 
 void blisp_common_progress_callback(uint32_t current_value, uint32_t max_value) {
-  printf("%" PRIu32 "b / %ldb (%.2f%%)\n", current_value, max_value,
+  printf("%" PRIu32 "b / %u (%.2f%%)\n", current_value, max_value,
          (((float)current_value / (float)max_value) * 100.0f));
 }
 

--- a/tools/blisp/src/util.c
+++ b/tools/blisp/src/util.c
@@ -35,6 +35,11 @@ ssize_t util_get_binary_folder(char* buffer, uint32_t buffer_size) {
 #elif defined(__APPLE__)
   util_get_executable_path(buffer, buffer_size);
   char* pos = strrchr(buffer, '/');
+#elif __FreeBSD__
+  if (readlink("/proc/curproc/file", buffer, buffer_size) <= 0) {
+    return -1;
+  }
+  char* pos = strrchr(buffer, '/');
 #else
   if (GetModuleFileName(NULL, buffer, buffer_size) <= 0) {
     return -1;

--- a/tools/blisp/src/util.h
+++ b/tools/blisp/src/util.h
@@ -4,9 +4,7 @@
 
 #include <stdint.h>
 
-#ifdef __linux__
-#include <unistd.h>
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #include <windows.h>
@@ -15,6 +13,8 @@ typedef SSIZE_T ssize_t;
 #include <sys/syslimits.h>
 #include <assert.h>
 #include <sys/types.h>
+#else
+#include <unistd.h>
 #endif
 
 ssize_t util_get_binary_folder(char* buffer, uint32_t buffer_size);


### PR DESCRIPTION
Here are some patches which enable building, running and flashing under FreeBSD operating system.
Also some misc patches which are fixing build warnings and updated README.

Later I'll try to import it to FreeBSD ports so it can be installed as package, without manual compilation.
It would be helpful it these changes are merged upstream.

```
./blisp write -c bl70x -p /dev/cuaU0 --reset firmware/Pinecilv2_EN.bin
Sending a handshake...
Handshake successful!
Getting chip info...
BootROM version 1.0.2.7, ChipID: 0000664BD7FDD7C4
0b / 59200 (0.00%)
4092b / 59200 (6.91%)
8184b / 59200 (13.82%)
12276b / 59200 (20.74%)
16368b / 59200 (27.65%)
20460b / 59200 (34.56%)
24552b / 59200 (41.47%)
28644b / 59200 (48.39%)
32736b / 59200 (55.30%)
36828b / 59200 (62.21%)
40920b / 59200 (69.12%)
45012b / 59200 (76.03%)
49104b / 59200 (82.95%)
53196b / 59200 (89.86%)
57288b / 59200 (96.77%)
59200b / 59200 (100.00%)
Sending a handshake...
Handshake with eflash_loader successful.
Erasing flash, this might take a while...
Flashing boot header...
Flashing the firmware...
0b / 57016 (0.00%)
252b / 57016 (0.44%)
504b / 57016 (0.88%)
756b / 57016 (1.33%)
1008b / 57016 (1.77%)
1260b / 57016 (2.21%)
1512b / 57016 (2.65%)
1764b / 57016 (3.09%)
2016b / 57016 (3.54%)
2268b / 57016 (3.98%)
2520b / 57016 (4.42%)
2772b / 57016 (4.86%)
3024b / 57016 (5.30%)
3276b / 57016 (5.75%)
3528b / 57016 (6.19%)
3780b / 57016 (6.63%)
4032b / 57016 (7.07%)
4284b / 57016 (7.51%)
4536b / 57016 (7.96%)
4788b / 57016 (8.40%)
5040b / 57016 (8.84%)
5292b / 57016 (9.28%)
5544b / 57016 (9.72%)
5796b / 57016 (10.17%)
6048b / 57016 (10.61%)
6300b / 57016 (11.05%)
6552b / 57016 (11.49%)
6804b / 57016 (11.93%)
7056b / 57016 (12.38%)
7308b / 57016 (12.82%)
7560b / 57016 (13.26%)
7812b / 57016 (13.70%)
8064b / 57016 (14.14%)
8316b / 57016 (14.59%)
8568b / 57016 (15.03%)
8820b / 57016 (15.47%)
9072b / 57016 (15.91%)
9324b / 57016 (16.35%)
9576b / 57016 (16.80%)
9828b / 57016 (17.24%)
10080b / 57016 (17.68%)
10332b / 57016 (18.12%)
10584b / 57016 (18.56%)
10836b / 57016 (19.01%)
11088b / 57016 (19.45%)
11340b / 57016 (19.89%)
11592b / 57016 (20.33%)
11844b / 57016 (20.77%)
12096b / 57016 (21.22%)
12348b / 57016 (21.66%)
12600b / 57016 (22.10%)
12852b / 57016 (22.54%)
13104b / 57016 (22.98%)
13356b / 57016 (23.43%)
13608b / 57016 (23.87%)
13860b / 57016 (24.31%)
14112b / 57016 (24.75%)
14364b / 57016 (25.19%)
14616b / 57016 (25.63%)
14868b / 57016 (26.08%)
15120b / 57016 (26.52%)
15372b / 57016 (26.96%)
15624b / 57016 (27.40%)
15876b / 57016 (27.84%)
16128b / 57016 (28.29%)
16380b / 57016 (28.73%)
16632b / 57016 (29.17%)
16884b / 57016 (29.61%)
17136b / 57016 (30.05%)
17388b / 57016 (30.50%)
17640b / 57016 (30.94%)
17892b / 57016 (31.38%)
18144b / 57016 (31.82%)
18396b / 57016 (32.26%)
18648b / 57016 (32.71%)
18900b / 57016 (33.15%)
19152b / 57016 (33.59%)
19404b / 57016 (34.03%)
19656b / 57016 (34.47%)
19908b / 57016 (34.92%)
20160b / 57016 (35.36%)
20412b / 57016 (35.80%)
20664b / 57016 (36.24%)
20916b / 57016 (36.68%)
21168b / 57016 (37.13%)
21420b / 57016 (37.57%)
21672b / 57016 (38.01%)
21924b / 57016 (38.45%)
22176b / 57016 (38.89%)
22428b / 57016 (39.34%)
22680b / 57016 (39.78%)
22932b / 57016 (40.22%)
23184b / 57016 (40.66%)
23436b / 57016 (41.10%)
23688b / 57016 (41.55%)
23940b / 57016 (41.99%)
24192b / 57016 (42.43%)
24444b / 57016 (42.87%)
24696b / 57016 (43.31%)
24948b / 57016 (43.76%)
25200b / 57016 (44.20%)
25452b / 57016 (44.64%)
25704b / 57016 (45.08%)
25956b / 57016 (45.52%)
26208b / 57016 (45.97%)
26460b / 57016 (46.41%)
26712b / 57016 (46.85%)
26964b / 57016 (47.29%)
27216b / 57016 (47.73%)
27468b / 57016 (48.18%)
27720b / 57016 (48.62%)
27972b / 57016 (49.06%)
28224b / 57016 (49.50%)
28476b / 57016 (49.94%)
28728b / 57016 (50.39%)
28980b / 57016 (50.83%)
29232b / 57016 (51.27%)
29484b / 57016 (51.71%)
29736b / 57016 (52.15%)
29988b / 57016 (52.60%)
30240b / 57016 (53.04%)
30492b / 57016 (53.48%)
30744b / 57016 (53.92%)
30996b / 57016 (54.36%)
31248b / 57016 (54.81%)
31500b / 57016 (55.25%)
31752b / 57016 (55.69%)
32004b / 57016 (56.13%)
32256b / 57016 (56.57%)
32508b / 57016 (57.02%)
32760b / 57016 (57.46%)
33012b / 57016 (57.90%)
33264b / 57016 (58.34%)
33516b / 57016 (58.78%)
33768b / 57016 (59.23%)
34020b / 57016 (59.67%)
34272b / 57016 (60.11%)
34524b / 57016 (60.55%)
34776b / 57016 (60.99%)
35028b / 57016 (61.44%)
35280b / 57016 (61.88%)
35532b / 57016 (62.32%)
35784b / 57016 (62.76%)
36036b / 57016 (63.20%)
36288b / 57016 (63.65%)
36540b / 57016 (64.09%)
36792b / 57016 (64.53%)
37044b / 57016 (64.97%)
37296b / 57016 (65.41%)
37548b / 57016 (65.86%)
37800b / 57016 (66.30%)
38052b / 57016 (66.74%)
38304b / 57016 (67.18%)
38556b / 57016 (67.62%)
38808b / 57016 (68.07%)
39060b / 57016 (68.51%)
39312b / 57016 (68.95%)
39564b / 57016 (69.39%)
39816b / 57016 (69.83%)
40068b / 57016 (70.28%)
40320b / 57016 (70.72%)
40572b / 57016 (71.16%)
40824b / 57016 (71.60%)
41076b / 57016 (72.04%)
41328b / 57016 (72.48%)
41580b / 57016 (72.93%)
41832b / 57016 (73.37%)
42084b / 57016 (73.81%)
42336b / 57016 (74.25%)
42588b / 57016 (74.69%)
42840b / 57016 (75.14%)
43092b / 57016 (75.58%)
43344b / 57016 (76.02%)
43596b / 57016 (76.46%)
43848b / 57016 (76.90%)
44100b / 57016 (77.35%)
44352b / 57016 (77.79%)
44604b / 57016 (78.23%)
44856b / 57016 (78.67%)
45108b / 57016 (79.11%)
45360b / 57016 (79.56%)
45612b / 57016 (80.00%)
45864b / 57016 (80.44%)
46116b / 57016 (80.88%)
46368b / 57016 (81.32%)
46620b / 57016 (81.77%)
46872b / 57016 (82.21%)
47124b / 57016 (82.65%)
47376b / 57016 (83.09%)
47628b / 57016 (83.53%)
47880b / 57016 (83.98%)
48132b / 57016 (84.42%)
48384b / 57016 (84.86%)
48636b / 57016 (85.30%)
48888b / 57016 (85.74%)
49140b / 57016 (86.19%)
49392b / 57016 (86.63%)
49644b / 57016 (87.07%)
49896b / 57016 (87.51%)
50148b / 57016 (87.95%)
50400b / 57016 (88.40%)
50652b / 57016 (88.84%)
50904b / 57016 (89.28%)
51156b / 57016 (89.72%)
51408b / 57016 (90.16%)
51660b / 57016 (90.61%)
51912b / 57016 (91.05%)
52164b / 57016 (91.49%)
52416b / 57016 (91.93%)
52668b / 57016 (92.37%)
52920b / 57016 (92.82%)
53172b / 57016 (93.26%)
53424b / 57016 (93.70%)
53676b / 57016 (94.14%)
53928b / 57016 (94.58%)
54180b / 57016 (95.03%)
54432b / 57016 (95.47%)
54684b / 57016 (95.91%)
54936b / 57016 (96.35%)
55188b / 57016 (96.79%)
55440b / 57016 (97.24%)
55692b / 57016 (97.68%)
55944b / 57016 (98.12%)
56196b / 57016 (98.56%)
56448b / 57016 (99.00%)
56700b / 57016 (99.45%)
56952b / 57016 (99.89%)
57016b / 57016 (100.00%)
Checking program...
Program OK!
Resetting the chip.
Flash complete!
```