### PR TITLE
Update instructions, syntax error in flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ cmake --build .
 For BL70X, BL61X, BL808 and BL606P, connected via USB, you can use following command, which will auto-detect serial port:
 
 ```bash
-blisp write --chip bl70x --reset name_of_firmware.bin
+.\blisp.exe write --chip=bl70x --reset .\name_of_firmware.bin
+or
+.\blisp.exe write -c bl70x --reset .\name_of_firmware.bin
 ```
 
 For BL60X, you need to specify also the serial port path:


### PR DESCRIPTION
syntax error in instructions. this command as written will not work because if flag `--chip`   is used, then it needs to be
 `--chip=bl70x`  with the **`=`**

**This as written will not work:** 
`blisp write --chip bl70x --reset name_of_firmware.bin` 

or if "=" is not desired then command **`-c bl70x`** could be used instead.

Either of these work:
-c, --chip**=**<chip_type>    Chip Type