### PR TITLE
Add support for building against system libraries of libserialport an…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,3 +64,79 @@ jobs:
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error 
+
+  build-linux-alternative-arch:
+    runs-on: ubuntu-latest
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    # Run steps on a matrix of 4 arch/distro combinations
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu_latest
+          - arch: armv7
+            distro: ubuntu_latest
+          - arch: riscv64
+            distro: ubuntu_latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          # Create an artifacts directory
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+
+          # Mount the artifacts directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+
+          # Pass some environment variables to the container
+          env: | # YAML, but pipe character is necessary
+            artifact_name: blisp-${{ matrix.distro }}_${{ matrix.arch }}
+
+          # The shell to run commands with in the container
+          shell: /bin/sh
+
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster|bullseye)
+                apt-get update -q -y
+                apt-get install -q -y git cmake build-essential
+                ;;
+            esac
+
+          # Produce a binary artifact and place it in the mounted volume
+          run: |
+            git submodule update --init --recursive
+            mkdir build
+            cd build
+            cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
+            cmake --build .
+            ls -lah build/tools/blisp/
+            cp build/tools/blisp/blisp "/artifacts/${artifact_name}"
+            echo "Produced artifact at /artifacts/${artifact_name}"
+
+      - name: Show the artifact
+        # Items placed in /artifacts in the container will be in
+        # ${PWD}/artifacts on the host.
+        run: |
+          ls -al "${PWD}/artifacts"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            build/tools/blisp/*
+          if-no-files-found: error 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
           # Pass some environment variables to the container
           env: | # YAML, but pipe character is necessary
-            artifact_name: blisp-${{ matrix.distro }}_${{ matrix.arch }}
+            artifact_name: blisp-linux-${{ matrix.arch }}
 
           # The shell to run commands with in the container
           shell: /bin/sh
@@ -128,20 +128,14 @@ jobs:
             mkdir build
             cd build
             cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
-            cmake --build .
-            ls -lah build/tools/blisp/
-            cp build/tools/blisp/blisp "/artifacts/${artifact_name}"
+            cmake --build . -j2
+            cp ./tools/blisp/blisp "/artifacts/${artifact_name}"
             echo "Produced artifact at /artifacts/${artifact_name}"
-
-      - name: Show the artifact
-        # Items placed in /artifacts in the container will be in
-        # ${PWD}/artifacts on the host.
-        run: |
-          ls -al "${PWD}/artifacts"
 
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
+          name: blisp-linux-${{ matrix.arch }}
           path: |
-            build/tools/blisp/*
+            artifacts/blisp-*
           if-no-files-found: error 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp Windows x64 build
           path: |
@@ -40,7 +40,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build .
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp macOS x64 build
           path: |
@@ -61,7 +61,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build .
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp Linux x64 build
           path: |
@@ -133,7 +133,7 @@ jobs:
             echo "Produced artifact at /artifacts/${artifact_name}"
 
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp-linux-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,12 @@ jobs:
       run:
         shell: cmd
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: lukka/get-cmake@latest
       - name: Build blisp tool
         run: |
-          git submodule update --init --recursive
           mkdir build
           cd build
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
@@ -28,11 +29,12 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: lukka/get-cmake@latest
       - name: Build blisp tool
         run: |
-          git submodule update --init --recursive
           mkdir build
           cd build
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
@@ -48,11 +50,12 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: lukka/get-cmake@latest
       - name: Build blisp tool
         run: |
-          git submodule update --init --recursive
           mkdir build
           cd build
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
@@ -81,6 +84,8 @@ jobs:
             distro: ubuntu_latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: uraimo/run-on-arch-action@v2
         name: Build artifact
         id: build
@@ -119,7 +124,7 @@ jobs:
 
           # Produce a binary artifact and place it in the mounted volume
           run: |
-            git submodule update --init --recursive
+            git config --global --add safe.directory /home/runner/work/blisp/blisp
             mkdir build
             cd build
             cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp Windows x64 build
+          name: blips-windows-x86_64.zip
           path: |
             build/tools/blisp/Release/blisp.exe
           if-no-files-found: error
@@ -42,7 +42,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp macOS x64 build
+          name: blips-apple-x86_64.zip
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error
@@ -63,7 +63,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp Linux x64 build
+          name: blips-linux-x86_64.zip
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error 
@@ -135,7 +135,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp-linux-${{ matrix.arch }}
+          name: blisp-linux-${{ matrix.arch }}.zip
           path: |
             artifacts/blisp-*
           if-no-files-found: error 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,22 @@ set_property(TARGET libblisp_obj PROPERTY POSITION_INDEPENDENT_CODE 1)
 add_library(libblisp SHARED $<TARGET_OBJECTS:libblisp_obj>)
 add_library(libblisp_static STATIC $<TARGET_OBJECTS:libblisp_obj>)
 
+set(BLISP_PUBLIC_HEADERS
+    include/blisp.h
+    include/blisp_easy.h
+    include/blisp_chip.h
+    include/blisp_struct.h
+    include/blisp_util.h)
 
 set_target_properties(libblisp PROPERTIES
-        PUBLIC_HEADER "include/blisp.h"
+        PUBLIC_HEADER "${BLISP_PUBLIC_HEADERS}"
         VERSION 0.0.3
         SOVERSION 1
         LIBRARY_OUTPUT_DIRECTORY "shared"
         OUTPUT_NAME "blisp")
 
 set_target_properties(libblisp_static PROPERTIES
-        PUBLIC_HEADER "include/blisp.h"
+        PUBLIC_HEADER "${BLISP_PUBLIC_HEADERS}"
         VERSION 0.0.3
         SOVERSION 1
         ARCHIVE_OUTPUT_DIRECTORY "static"
@@ -82,6 +88,8 @@ else()
         write_file(${CMAKE_SOURCE_DIR}/vendor/libserialport/config.h "// bypass errors.")
     endif()
 endif()
+
+install(TARGETS libblisp libblisp_static DESTINATION lib)
 
 if(BLISP_BUILD_CLI)
     add_subdirectory(tools/blisp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(blisp C)
 set(CMAKE_C_STANDARD 23)
 
 option(BLISP_BUILD_CLI "Build CLI Tool" OFF)
+option(BLISP_USE_SYSTEM_LIBRARIES "Use system-installed libraries" "${CMAKE_USE_SYSTEM_LIBRARIES}")
 
 add_library(libblisp_obj OBJECT
         lib/blisp.c
@@ -32,46 +33,54 @@ set_target_properties(libblisp_static PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY "static"
         OUTPUT_NAME "blisp")
 
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-target_sources(libblisp_obj PRIVATE
+if(BLISP_USE_SYSTEM_LIBRARIES)
+    find_package(PkgConfig)
+    pkg_search_module(LIBSERIALPORT REQUIRED libserialport)
+    target_link_libraries(libblisp PUBLIC ${LIBSERIALPORT_LIBRARIES})
+    target_link_libraries(libblisp_static PUBLIC ${LIBSERIALPORT_LIBRARIES})
+    target_include_directories(libblisp_obj PUBLIC ${LIBSERIALPORT_INCLUDE_DIRS})
+else()
+	if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+	target_sources(libblisp_obj PRIVATE
         ${CMAKE_SOURCE_DIR}/vendor/libserialport/serialport.c
         ${CMAKE_SOURCE_DIR}/vendor/libserialport/timing.c)
 
-target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/vendor/libserialport)
-endif()
+	target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/vendor/libserialport)
+	endif()
 
-if(WIN32)
-    target_link_libraries(libblisp PRIVATE Setupapi.lib)
-    target_link_libraries(libblisp_static PRIVATE Setupapi.lib)
-    target_compile_definitions(libblisp_obj PRIVATE LIBSERIALPORT_MSBUILD)
-    target_sources(libblisp_obj PRIVATE
-            ${CMAKE_SOURCE_DIR}/vendor/libserialport/windows.c)
-elseif(UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    target_sources(libblisp_obj PRIVATE
-            ${CMAKE_SOURCE_DIR}/vendor/libserialport/linux.c
-            ${CMAKE_SOURCE_DIR}/vendor/libserialport/linux_termios.c)
-    target_compile_definitions(libblisp_obj PRIVATE
-            LIBSERIALPORT_ATBUILD
-            HAVE_TERMIOS2_SPEED
-            HAVE_STRUCT_TERMIOS2
-            HAVE_DECL_BOTHER
-            "SP_API=__attribute__((visibility(\"default\")))"
-            "SP_PRIV=__attribute__((visibility(\"hidden\")))")
-    write_file(${CMAKE_SOURCE_DIR}/vendor/libserialport/config.h "// bypass errors.")
-elseif(UNIX AND ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    target_include_directories(libblisp_obj PRIVATE /usr/local/include/)
-    target_link_libraries(libblisp PRIVATE -L/usr/local/lib usb serialport)
-    target_link_libraries(libblisp_static PRIVATE -L/usr/local/lib usb serialport)
-elseif(APPLE)
-    target_sources(libblisp_obj PRIVATE
-            ${CMAKE_SOURCE_DIR}/vendor/libserialport/macosx.c)
-    target_link_libraries(libblisp PRIVATE "-framework IOKit" "-framework CoreFoundation")
-    target_compile_definitions(libblisp_obj PRIVATE
-            LIBSERIALPORT_ATBUILD
-            "SP_PRIV=__attribute__((visibility(\"hidden\")))"
-            "SP_API=__attribute__((visibility(\"default\")))")
-    target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/vendor/libserialport)
-    write_file(${CMAKE_SOURCE_DIR}/vendor/libserialport/config.h "// bypass errors.")
+    if(WIN32)
+        target_link_libraries(libblisp PRIVATE Setupapi.lib)
+        target_link_libraries(libblisp_static PRIVATE Setupapi.lib)
+        target_compile_definitions(libblisp_obj PRIVATE LIBSERIALPORT_MSBUILD)
+        target_sources(libblisp_obj PRIVATE
+                ${CMAKE_SOURCE_DIR}/vendor/libserialport/windows.c)
+    elseif(UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+        target_sources(libblisp_obj PRIVATE
+                ${CMAKE_SOURCE_DIR}/vendor/libserialport/linux.c
+                ${CMAKE_SOURCE_DIR}/vendor/libserialport/linux_termios.c)
+        target_compile_definitions(libblisp_obj PRIVATE
+                LIBSERIALPORT_ATBUILD
+                HAVE_TERMIOS2_SPEED
+                HAVE_STRUCT_TERMIOS2
+                HAVE_DECL_BOTHER
+                "SP_API=__attribute__((visibility(\"default\")))"
+                "SP_PRIV=__attribute__((visibility(\"hidden\")))")
+        write_file(${CMAKE_SOURCE_DIR}/vendor/libserialport/config.h "// bypass errors.")
+    elseif(UNIX AND ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+        target_include_directories(libblisp_obj PRIVATE /usr/local/include/)
+        target_link_libraries(libblisp PRIVATE -L/usr/local/lib usb serialport)
+        target_link_libraries(libblisp_static PRIVATE -L/usr/local/lib usb serialport)
+    elseif(APPLE)
+        target_sources(libblisp_obj PRIVATE
+                ${CMAKE_SOURCE_DIR}/vendor/libserialport/macosx.c)
+        target_link_libraries(libblisp PRIVATE "-framework IOKit" "-framework CoreFoundation")
+        target_compile_definitions(libblisp_obj PRIVATE
+                LIBSERIALPORT_ATBUILD
+                "SP_PRIV=__attribute__((visibility(\"hidden\")))"
+                "SP_API=__attribute__((visibility(\"default\")))")
+        target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/vendor/libserialport)
+        write_file(${CMAKE_SOURCE_DIR}/vendor/libserialport/config.h "// bypass errors.")
+    endif()
 endif()
 
 if(BLISP_BUILD_CLI)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ mkdir build && cd build
 cmake -DBLISP_BUILD_CLI=ON ..
 cmake --build .
 ```
+
+For building against preinstalled system libraries of the used vendor
+libraries (system maintainers), additionally define
+`BLISP_USE_SYSTEM_LIBRARIES`, e.g. using following commands:
+```bash
+mkdir build && cd build
+cmake -DBLISP_USE_SYSTEM_LIBRARIES=ON -DBLISP_BUILD_CLI=ON ..
+cmake --build .
+```
+
 #### Need more build details? [See here](https://github.com/pine64/blisp/wiki/Update-Pinecil-V2#build-blisp-flasher-from-code).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cmake --build .
 ```
 
 For building against preinstalled system libraries of the used vendor
-libraries (system maintainers), additionally define
+libraries (e.g. for use by system maintainers), additionally define
 `BLISP_USE_SYSTEM_LIBRARIES`, e.g. using following commands:
 ```bash
 mkdir build && cd build

--- a/tools/blisp/CMakeLists.txt
+++ b/tools/blisp/CMakeLists.txt
@@ -2,17 +2,19 @@ set(ARGTABLE3_ENABLE_TESTS OFF CACHE BOOL "Enable unit tests")
 set(ARGTABLE3_ENABLE_EXAMPLES OFF CACHE BOOL "Enable examples")
 #set(ARGTABLE3_REPLACE_GETOPT OFF CACHE BOOL "Replace getopt in the system C library")
 
-if(BLISP_USE_SYSTEM_LIBRARIES)
-    find_package(Argtable3)
-else()
-    add_subdirectory(${CMAKE_SOURCE_DIR}/vendor/argtable3 ${CMAKE_CURRENT_BINARY_DIR}/argtable3)
-endif()
-
 add_executable(blisp src/main.c src/cmd/write.c src/util.c src/common.c src/cmd/iot.c)
 
-target_include_directories(blisp PRIVATE
-        "${CMAKE_SOURCE_DIR}/include"
+if(BLISP_USE_SYSTEM_LIBRARIES)
+    find_package(Argtable3 REQUIRED)
+else()
+    add_subdirectory(${CMAKE_SOURCE_DIR}/vendor/argtable3 ${CMAKE_CURRENT_BINARY_DIR}/argtable3)
+
+    target_include_directories(blisp PRIVATE
         "${CMAKE_SOURCE_DIR}/vendor/argtable3/src")
+endif()
+
+target_include_directories(blisp PRIVATE
+        "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(blisp PRIVATE
         argtable3

--- a/tools/blisp/CMakeLists.txt
+++ b/tools/blisp/CMakeLists.txt
@@ -25,3 +25,5 @@ if (WIN32)
 elseif (APPLE)
     target_link_libraries(blisp PRIVATE "-framework IOKit" "-framework CoreFoundation")
 endif ()
+
+install(TARGETS blisp DESTINATION bin)

--- a/tools/blisp/CMakeLists.txt
+++ b/tools/blisp/CMakeLists.txt
@@ -1,7 +1,12 @@
 set(ARGTABLE3_ENABLE_TESTS OFF CACHE BOOL "Enable unit tests")
 set(ARGTABLE3_ENABLE_EXAMPLES OFF CACHE BOOL "Enable examples")
 #set(ARGTABLE3_REPLACE_GETOPT OFF CACHE BOOL "Replace getopt in the system C library")
-add_subdirectory(${CMAKE_SOURCE_DIR}/vendor/argtable3 ${CMAKE_CURRENT_BINARY_DIR}/argtable3)
+
+if(BLISP_USE_SYSTEM_LIBRARIES)
+    find_package(Argtable3)
+else()
+    add_subdirectory(${CMAKE_SOURCE_DIR}/vendor/argtable3 ${CMAKE_CURRENT_BINARY_DIR}/argtable3)
+endif()
 
 add_executable(blisp src/main.c src/cmd/write.c src/util.c src/common.c src/cmd/iot.c)
 


### PR DESCRIPTION
Allow building against existing system libraries of libserialport and argtable.
By default (new variable unset), still prepackages vendor libraries should be used for build.

Proposal to fix created issue:
Resolves #35 