### PR TITLE
Refactor to address compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,15 @@ add_library(libblisp_obj OBJECT
         lib/chip/blisp_chip_bl70x.c)
 
 target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/include/)
+if (NOT CMAKE_C_COMPILER_ID MATCHES "MSVC")
+  target_compile_options(libblisp_obj PRIVATE -Wall -Wextra -Wpedantic)
+else()
+  # MSVC does not support 'extra' and 'pedantic' levels to warnings.
+  # `/Wall` seems to generate way too many non-actionable output marked as warnings.
+  # We settle for `/W4`.
+  # https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-170
+  target_compile_options(libblisp_obj PRIVATE -W4)
+endif()
 
 set_property(TARGET libblisp_obj PROPERTY POSITION_INDEPENDENT_CODE 1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,10 @@ option(COMPILE_TESTS "Compile the tests" OFF)
 
 add_library(libblisp_obj OBJECT
         lib/blisp.c
+        lib/blisp_easy.c
+        lib/blisp_util.c
         lib/chip/blisp_chip_bl60x.c
-        lib/chip/blisp_chip_bl70x.c lib/blisp_easy.c)
+        lib/chip/blisp_chip_bl70x.c)
 
 target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/include/)
 

--- a/include/blisp.h
+++ b/include/blisp.h
@@ -31,34 +31,34 @@ struct blisp_boot_info {
 // TODO: Refactor variable names, so all will follow same semantic, like
 // image_run, image_check etc.
 
-int32_t blisp_device_init(struct blisp_device* device, struct blisp_chip* chip);
-int32_t blisp_device_open(struct blisp_device* device, const char* port_name);
-int32_t blisp_device_handshake(struct blisp_device* device, bool in_ef_loader);
-int32_t blisp_device_get_boot_info(struct blisp_device* device,
+blisp_return_t blisp_device_init(struct blisp_device* device, struct blisp_chip* chip);
+blisp_return_t blisp_device_open(struct blisp_device* device, const char* port_name);
+blisp_return_t blisp_device_handshake(struct blisp_device* device, bool in_ef_loader);
+blisp_return_t blisp_device_get_boot_info(struct blisp_device* device,
                                    struct blisp_boot_info* boot_info);
-int32_t blisp_device_load_boot_header(struct blisp_device* device,
+blisp_return_t blisp_device_load_boot_header(struct blisp_device* device,
                                       uint8_t* boot_header);
-int32_t blisp_device_load_segment_header(
+blisp_return_t blisp_device_load_segment_header(
     struct blisp_device* device,
     struct blisp_segment_header* segment_header);
-int32_t blisp_device_load_segment_data(struct blisp_device* device,
+blisp_return_t blisp_device_load_segment_data(struct blisp_device* device,
                                        uint8_t* segment_data,
                                        uint32_t segment_data_length);
-int32_t blisp_device_write_memory(struct blisp_device* device,
+blisp_return_t blisp_device_write_memory(struct blisp_device* device,
                                   uint32_t address,
                                   uint32_t value,
                                   bool wait_for_res);
-int32_t blisp_device_check_image(struct blisp_device* device);
-int32_t blisp_device_run_image(struct blisp_device* device);
-int32_t blisp_device_flash_erase(struct blisp_device* device,
+blisp_return_t blisp_device_check_image(struct blisp_device* device);
+blisp_return_t blisp_device_run_image(struct blisp_device* device);
+blisp_return_t blisp_device_flash_erase(struct blisp_device* device,
                                  uint32_t start_address,
                                  uint32_t end_address);
-int32_t blisp_device_flash_write(struct blisp_device* device,
+blisp_return_t blisp_device_flash_write(struct blisp_device* device,
                                  uint32_t start_address,
                                  uint8_t* payload,
                                  uint32_t payload_size);
-int32_t blisp_device_program_check(struct blisp_device* device);
-int32_t blisp_device_reset(struct blisp_device* device);
+blisp_return_t blisp_device_program_check(struct blisp_device* device);
+blisp_return_t blisp_device_reset(struct blisp_device* device);
 void blisp_device_close(struct blisp_device* device);
 
 #endif

--- a/include/blisp_util.h
+++ b/include/blisp_util.h
@@ -2,35 +2,18 @@
 #ifndef _BLISP_UTIL_H
 #define _BLISP_UTIL_H
 
-#include <stdarg.h>
-#include <stdio.h>
+#include <stdint.h>
 #ifdef WIN32
-#include <windows.h>
+#  include <windows.h>
 #else
-#include <time.h>
+#  include <time.h>
 #endif
 
-static void blisp_dlog(const char* format, ...)
-{
-  fflush(stdout);
-  va_list args;
-  va_start(args, format);
-  vfprintf(stderr, format, args);
-  va_end(args);
-  fputc('\n', stderr);
-}
+void blisp_dlog(const char* format, ...);
 
+void sleep_ms(int milliseconds);
 
-static void sleep_ms(int milliseconds) {
-#ifdef WIN32
-  Sleep(milliseconds);
-#else
-  struct timespec ts;
-  ts.tv_sec = milliseconds / 1000;
-  ts.tv_nsec = (milliseconds % 1000) * 1000000;
-  nanosleep(&ts, NULL);
-#endif
-}
+uint32_t crc32_calculate(const void *data, size_t data_len);
 
 /**
  * * Generated on Mon Jan  9 19:56:36 2023
@@ -79,20 +62,5 @@ static const uint32_t crc_table[256] = {
     0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
     0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
 };
-
-static uint32_t crc32_calculate(const void *data, size_t data_len)
-{
-  uint32_t crc = 0xffffffff;
-  const unsigned char *d = (const unsigned char *)data;
-  unsigned int tbl_idx;
-
-  while (data_len--) {
-    tbl_idx = (crc ^ *d) & 0xff;
-    crc = (crc_table[tbl_idx] ^ (crc >> 8)) & 0xffffffff;
-    d++;
-  }
-  return (crc & 0xffffffff) ^ 0xffffffff;
-}
-
 
 #endif

--- a/lib/blisp.c
+++ b/lib/blisp.c
@@ -16,6 +16,8 @@
 static void drain(struct sp_port* port) {
 #if defined(__APPLE__) || defined(__FreeBSD__)
   sp_drain(port);
+#else
+  (void)port; // unused
 #endif
 }
 

--- a/lib/blisp.c
+++ b/lib/blisp.c
@@ -30,7 +30,7 @@ blisp_return_t blisp_device_init(struct blisp_device* device,
 
 blisp_return_t blisp_device_open(struct blisp_device* device,
                                  const char* port_name) {
-  blisp_return_t ret;
+  enum sp_return ret;
   struct sp_port* serial_port = NULL;
 
   if (port_name != NULL) {

--- a/lib/blisp.c
+++ b/lib/blisp.c
@@ -192,8 +192,8 @@ blisp_return_t blisp_device_handshake(struct blisp_device* device,
     sleep_ms(50);  // Wait a bit so BootROM can init
   }
 
-  uint32_t bytes_count = device->chip->handshake_byte_multiplier *
-                         (float)device->current_baud_rate / 10.0f;
+  uint32_t bytes_count = (uint32_t)(device->chip->handshake_byte_multiplier *
+                                    (float)device->current_baud_rate / 10.0f);
   if (bytes_count > 600)
     bytes_count = 600;
   memset(handshake_buffer, 'U', bytes_count);

--- a/lib/blisp_util.c
+++ b/lib/blisp_util.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef WIN32
+#  include <windows.h>
+#else
+#  include <time.h>
+#endif
+
+#include "blisp_util.h"
+
+void blisp_dlog(const char* format, ...)
+{
+  fflush(stdout);
+  va_list args;
+  va_start(args, format);
+  vfprintf(stderr, format, args);
+  va_end(args);
+  fputc('\n', stderr);
+}
+
+
+void sleep_ms(int milliseconds) {
+#ifdef WIN32
+  Sleep(milliseconds);
+#else
+  struct timespec ts;
+  ts.tv_sec = milliseconds / 1000;
+  ts.tv_nsec = (milliseconds % 1000) * 1000000;
+  nanosleep(&ts, NULL);
+#endif
+}
+
+uint32_t crc32_calculate(const void *data, size_t data_len)
+{
+  uint32_t crc = 0xffffffff;
+  const unsigned char *d = (const unsigned char *)data;
+  unsigned int tbl_idx;
+
+  while (data_len--) {
+    tbl_idx = (crc ^ *d) & 0xff;
+    crc = (crc_table[tbl_idx] ^ (crc >> 8)) & 0xffffffff;
+    d++;
+  }
+  return (crc & 0xffffffff) ^ 0xffffffff;
+}

--- a/lib/chip/blisp_chip_bl60x.c
+++ b/lib/chip/blisp_chip_bl60x.c
@@ -6,6 +6,8 @@
 
 int64_t blisp_chip_bl60x_get_eflash_loader(uint8_t clk_type, uint8_t** firmware_buf_ptr)
 {
+  (void)clk_type; // unused
+
   uint8_t* firmware_buf = malloc(sizeof(bl60x_eflash_loader_bin));
   memcpy(firmware_buf, bl60x_eflash_loader_bin, sizeof(bl60x_eflash_loader_bin));
   *(firmware_buf + 0xE0) = 4; // TODO: 40 MHz clock

--- a/lib/chip/blisp_chip_bl70x.c
+++ b/lib/chip/blisp_chip_bl70x.c
@@ -6,6 +6,8 @@
 
 int64_t blisp_chip_bl70x_get_eflash_loader(uint8_t clk_type, uint8_t** firmware_buf_ptr)
 {
+  (void) clk_type; // ununsed
+
   uint8_t* firmware_buf = malloc(sizeof(bl70x_eflash_loader_bin));
   memcpy(firmware_buf, bl70x_eflash_loader_bin, sizeof(bl70x_eflash_loader_bin));
   *(firmware_buf + 0xE0) = 1; // TODO: 32 MHz clock

--- a/tools/blisp/CMakeLists.txt
+++ b/tools/blisp/CMakeLists.txt
@@ -23,6 +23,16 @@ target_link_libraries(blisp PRIVATE
         argtable3::argtable3
         libblisp_static file_parsers)
 
+if (NOT CMAKE_C_COMPILER_ID MATCHES "MSVC")
+  target_compile_options(libblisp_obj PRIVATE -Wall -Wextra -Wpedantic)
+else()
+  # MSVC does not support 'extra' and 'pedantic' levels to warnings.
+  # `/Wall` seems to generate way too many non-actionable output marked as warnings.
+  # We settle for `/W4`.
+  # https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-170
+  target_compile_options(libblisp_obj PRIVATE -W4)
+endif()
+
 if (WIN32)
     target_link_libraries(blisp PRIVATE Setupapi.lib)
 elseif (APPLE)

--- a/tools/blisp/src/cmd/write.c
+++ b/tools/blisp/src/cmd/write.c
@@ -168,31 +168,35 @@ void fill_up_boot_header(struct bfl_boot_header* boot_header) {
 
 blisp_return_t blisp_flash_firmware() {
   struct blisp_device device;
-  blisp_return_t ret;
+  blisp_return_t ret = BLISP_OK;
 
   if (access(binary_to_write->filename[0], R_OK) != 0) {
     // File not accessible, error out.
     fprintf(stderr, "Input firmware not found: %s\n", binary_to_write->filename[0]);
     cmd_write_args_print_glossary(); /* Print help to assist user */
     /* No need to free memory, will now exit with ret code 1 */
-    return 1;
+    return BLISP_ERR_CANT_OPEN_FILE;
   }
 
   ret = blisp_common_init_device(&device, port_name, chip_type);
-
-  if (ret != 0) {
+  if (ret != BLISP_OK) {
     return ret;
   }
 
-  if (blisp_common_prepare_flash(&device) != 0) {
+  ret = blisp_common_prepare_flash(&device);
+  if (ret != BLISP_OK) {
     // TODO: Error handling
     goto exit1;
   }
 
   parsed_firmware_file_t parsed_file;
   memset(&parsed_file, 0, sizeof(parsed_file));
-  int parsed_result =
-      parse_firmware_file(binary_to_write->filename[0], &parsed_file);
+  if (parse_firmware_file(binary_to_write->filename[0], &parsed_file) < 0) {
+    // `parse_firmware_file` doesn't return `blisp_return_t`
+    // so we default to the generic error.
+    ret = BLISP_ERR_UNKNOWN;
+    goto exit1;
+  }
 
   // If we are injecting a bootloader section, make it, erase flash, and flash
   // it. Then when we do firmware later on; it will be located afterwards
@@ -249,7 +253,7 @@ blisp_return_t blisp_flash_firmware() {
       &device, &data_transport, parsed_file.payload_address,
       parsed_file.payload_length, blisp_common_progress_callback);
 
-  if (ret < BLISP_OK) {
+  if (ret != BLISP_OK) {
     fprintf(stderr, "Failed to write app to flash.\n");
     goto exit2;
   }
@@ -275,6 +279,8 @@ exit2:
     free(parsed_file.payload);
 exit1:
   blisp_device_close(&device);
+
+  return ret;
 }
 
 blisp_return_t cmd_write_args_init() {

--- a/tools/blisp/src/cmd/write.c
+++ b/tools/blisp/src/cmd/write.c
@@ -237,13 +237,13 @@ blisp_return_t blisp_flash_firmware() {
 
   if (ret != BLISP_OK) {
     fprintf(stderr,
-            "Failed to erase flash. Tried to erase from 0x%08lu to 0x%08lu\n",
+            "Failed to erase flash. Tried to erase from 0x%08zx to 0x%08zx\n",
             parsed_file.payload_address,
             parsed_file.payload_address + parsed_file.payload_length + 1);
     goto exit2;
   }
 
-  printf("Flashing the firmware %lu bytes @ 0x%08lu...\n",
+  printf("Flashing the firmware %zu bytes @ 0x%08zx...\n",
          parsed_file.payload_length, parsed_file.payload_address);
   struct blisp_easy_transport data_transport =
       blisp_easy_transport_new_from_memory(parsed_file.payload,

--- a/tools/blisp/src/common.h
+++ b/tools/blisp/src/common.h
@@ -6,8 +6,8 @@
 #include <blisp.h>
 #include <argtable3.h>
 
-int32_t blisp_common_prepare_flash(struct blisp_device* device);
+blisp_return_t blisp_common_prepare_flash(struct blisp_device* device);
 void blisp_common_progress_callback(uint32_t current_value, uint32_t max_value);
-int32_t blisp_common_init_device(struct blisp_device* device, struct arg_str* port_name, struct arg_str* chip_type);
+blisp_return_t blisp_common_init_device(struct blisp_device* device, struct arg_str* port_name, struct arg_str* chip_type);
 
 #endif  // BLISP_COMMON_H


### PR DESCRIPTION
- Unused function warnings Move function definitions in include/blisp_util.h to lib/blisp_util.c. Defining them as static leads to internal linkage, accessible in that translation unit, hence the warning. Their references are to be handled in other translation units, so they shouldn't be static.

- Unused function parameters Define a macro for void casting unused parameters as a portable-across-compilers way to suppress these warnings.

  - `blisp_chip_xxxxx_get_eflash_loader` implementations accept clock type but don't use it.

  - `drain` function only has a body under macOS and FreeBSD with preprocessor predicates.

- Enable compiler warnings Now that warnings are address enable them `-Wall -Wextra -Wpedantic` for the library and the tool targets.

N.B. An equivalent of MSVC should be added to CMakeLists.txt, as these would only work when using GCC or Clang.


Current warnings on `master`:
```
[  3%] Building C object CMakeFiles/libblisp_obj.dir/lib/blisp.c.o
/home/bdd/src/github/pine64/blisp/lib/blisp.c: In function ‘drain’:
/home/bdd/src/github/pine64/blisp/lib/blisp.c:16:35: warning: unused parameter ‘port’ [-Wunused-parameter]
   16 | static void drain(struct sp_port* port) {
      |                   ~~~~~~~~~~~~~~~~^~~~
In file included from /home/bdd/src/github/pine64/blisp/lib/blisp.c:3:
/home/bdd/src/github/pine64/blisp/include/blisp_util.h: At top level:
/home/bdd/src/github/pine64/blisp/include/blisp_util.h:83:17: warning: ‘crc32_calculate’ defined but not used [-Wunused-function]
   83 | static uint32_t crc32_calculate(const void *data, size_t data_len)
      |                 ^~~~~~~~~~~~~~~
[  6%] Building C object CMakeFiles/libblisp_obj.dir/lib/chip/blisp_chip_bl60x.c.o
/home/bdd/src/github/pine64/blisp/lib/chip/blisp_chip_bl60x.c: In function ‘blisp_chip_bl60x_get_eflash_loader’:
/home/bdd/src/github/pine64/blisp/lib/chip/blisp_chip_bl60x.c:7:52: warning: unused parameter ‘clk_type’ [-Wunused-parameter]
    7 | int64_t blisp_chip_bl60x_get_eflash_loader(uint8_t clk_type, uint8_t** firmware_buf_ptr)
      |                                            ~~~~~~~~^~~~~~~~
[  9%] Building C object CMakeFiles/libblisp_obj.dir/lib/chip/blisp_chip_bl70x.c.o
/home/bdd/src/github/pine64/blisp/lib/chip/blisp_chip_bl70x.c: In function ‘blisp_chip_bl70x_get_eflash_loader’:
/home/bdd/src/github/pine64/blisp/lib/chip/blisp_chip_bl70x.c:7:52: warning: unused parameter ‘clk_type’ [-Wunused-parameter]
    7 | int64_t blisp_chip_bl70x_get_eflash_loader(uint8_t clk_type, uint8_t** firmware_buf_ptr)
      |                                            ~~~~~~~~^~~~~~~~
[ 12%] Building C object CMakeFiles/libblisp_obj.dir/lib/blisp_easy.c.o
In file included from /home/bdd/src/github/pine64/blisp/lib/blisp_easy.c:4:
/home/bdd/src/github/pine64/blisp/include/blisp_util.h:24:13: warning: ‘sleep_ms’ defined but not used [-Wunused-function]
   24 | static void sleep_ms(int milliseconds) {
```