### PR TITLE
Add CMake installation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,22 @@ set_property(TARGET libblisp_obj PROPERTY POSITION_INDEPENDENT_CODE 1)
 add_library(libblisp SHARED $<TARGET_OBJECTS:libblisp_obj>)
 add_library(libblisp_static STATIC $<TARGET_OBJECTS:libblisp_obj>)
 
+set(BLISP_PUBLIC_HEADERS
+    include/blisp.h
+    include/blisp_easy.h
+    include/blisp_chip.h
+    include/blisp_struct.h
+    include/blisp_util.h)
 
 set_target_properties(libblisp PROPERTIES
-        PUBLIC_HEADER "include/blisp.h"
+        PUBLIC_HEADER "${BLISP_PUBLIC_HEADERS}"
         VERSION 0.0.3
         SOVERSION 1
         LIBRARY_OUTPUT_DIRECTORY "shared"
         OUTPUT_NAME "blisp")
 
 set_target_properties(libblisp_static PROPERTIES
-        PUBLIC_HEADER "include/blisp.h"
+        PUBLIC_HEADER "${BLISP_PUBLIC_HEADERS}"
         VERSION 0.0.3
         SOVERSION 1
         ARCHIVE_OUTPUT_DIRECTORY "static"
@@ -73,6 +79,8 @@ elseif(APPLE)
     target_include_directories(libblisp_obj PRIVATE ${CMAKE_SOURCE_DIR}/vendor/libserialport)
     write_file(${CMAKE_SOURCE_DIR}/vendor/libserialport/config.h "// bypass errors.")
 endif()
+
+install(TARGETS libblisp libblisp_static DESTINATION lib)
 
 if(BLISP_BUILD_CLI)
     add_subdirectory(tools/blisp)

--- a/tools/blisp/CMakeLists.txt
+++ b/tools/blisp/CMakeLists.txt
@@ -18,3 +18,5 @@ if (WIN32)
 elseif (APPLE)
     target_link_libraries(blisp PRIVATE "-framework IOKit" "-framework CoreFoundation")
 endif ()
+
+install(TARGETS blisp DESTINATION bin)


### PR DESCRIPTION
Allows installation with:
  `cmake --install . [--prefix /dir]`


Came across the lack of this while [packaging blisp CLI tool for Nixpkgs](https://github.com/NixOS/nixpkgs/pull/227474). 