### PR TITLE
Proper error codes (and return failure code)

### DIFF
--- a/include/blisp.h
+++ b/include/blisp.h
@@ -3,20 +3,8 @@
 #define _LIBBLISP_H
 
 #include <stdint.h>
-
 #include "blisp_chip.h"
-
-enum blisp_return {
-  BLISP_OK = 0,
-  BLISP_ERR_UNKNOWN = -1,
-  BLISP_ERR_NO_RESPONSE = -2,
-  BLISP_ERR_DEVICE_NOT_FOUND = -3,
-  BLISP_ERR_CANT_OPEN_DEVICE = -4,
-  // Can't auto-find device due it doesn't have native USB
-  BLISP_ERR_NO_AUTO_FIND_AVAILABLE = -5,
-  BLISP_ERR_PENDING = -6,
-  BLISP_ERR_CHIP_ERR = -7
-};
+#include "error_codes.h"
 
 struct blisp_segment_header {
   uint32_t dest_addr;

--- a/include/error_codes.h
+++ b/include/error_codes.h
@@ -1,0 +1,21 @@
+#ifndef BLISP_S_RC_ERROR_CODES_H_
+#define BLISP_S_RC_ERROR_CODES_H_
+
+typedef enum {
+  BLISP_OK = 0,
+  // All error states must be <0.
+  // Generic error return; for when we are unsure what failed
+  BLISP_ERR_UNKNOWN = -1,
+  // Device did not respond, if serial link, could be that its not in bootloader
+  BLISP_ERR_NO_RESPONSE = -2,
+  // Failed to open a device, likely libusb or permissions
+  BLISP_ERR_DEVICE_NOT_FOUND = -3,
+  BLISP_ERR_CANT_OPEN_DEVICE = -4,
+  // Can't auto-find device due it doesn't have native USB
+  BLISP_ERR_NO_AUTO_FIND_AVAILABLE = -5,
+  BLISP_ERR_PENDING = -6,
+  BLISP_ERR_CHIP_ERR = -7,
+  BLISP_ERR_INVALID_CHIP_TYPE = -8,
+
+} blisp_return_t;
+#endif

--- a/include/error_codes.h
+++ b/include/error_codes.h
@@ -19,6 +19,7 @@ typedef enum {
   BLISP_ERR_OUT_OF_MEMORY = -9,
   BLISP_ERR_INVALID_COMMAND = -10,
   BLISP_ERR_CANT_OPEN_FILE=-11,
+  BLISP_ERR_NOT_IMPLEMENTED=-12,
 
 } blisp_return_t;
 #endif

--- a/include/error_codes.h
+++ b/include/error_codes.h
@@ -16,6 +16,9 @@ typedef enum {
   BLISP_ERR_PENDING = -6,
   BLISP_ERR_CHIP_ERR = -7,
   BLISP_ERR_INVALID_CHIP_TYPE = -8,
+  BLISP_ERR_OUT_OF_MEMORY = -9,
+  BLISP_ERR_INVALID_COMMAND = -10,
+  BLISP_ERR_CANT_OPEN_FILE=-11,
 
 } blisp_return_t;
 #endif

--- a/include/error_codes.h
+++ b/include/error_codes.h
@@ -6,20 +6,25 @@ typedef enum {
   // All error states must be <0.
   // Generic error return; for when we are unsure what failed
   BLISP_ERR_UNKNOWN = -1,
-  // Device did not respond, if serial link, could be that its not in bootloader
+  // Device did not respond, if serial link, could be that its not in boot
+  // loader
   BLISP_ERR_NO_RESPONSE = -2,
   // Failed to open a device, likely libusb or permissions
-  BLISP_ERR_DEVICE_NOT_FOUND = -3,
-  BLISP_ERR_CANT_OPEN_DEVICE = -4,
+  BLISP_ERR_DEVICE_NOT_FOUND = -3,  // We could not find a device
+  BLISP_ERR_CANT_OPEN_DEVICE =
+      -4,  // Couldn't open device; could it be permissions or its in use?
   // Can't auto-find device due it doesn't have native USB
   BLISP_ERR_NO_AUTO_FIND_AVAILABLE = -5,
-  BLISP_ERR_PENDING = -6,
-  BLISP_ERR_CHIP_ERR = -7,
-  BLISP_ERR_INVALID_CHIP_TYPE = -8,
-  BLISP_ERR_OUT_OF_MEMORY = -9,
-  BLISP_ERR_INVALID_COMMAND = -10,
-  BLISP_ERR_CANT_OPEN_FILE=-11,
-  BLISP_ERR_NOT_IMPLEMENTED=-12,
+  BLISP_ERR_PENDING = -6,  // Internal error for device is busy and to come back
+  BLISP_ERR_CHIP_ERR = -7,           // Chip returned an error to us
+  BLISP_ERR_INVALID_CHIP_TYPE = -8,  // unsupported chip type provided
+  BLISP_ERR_OUT_OF_MEMORY =
+      -9,  // System could not allocate enough ram (highly unlikely)
+  BLISP_ERR_INVALID_COMMAND = -10,  // Invalid user command provided
+  BLISP_ERR_CANT_OPEN_FILE = -11,   // Cant open the firmware file to flash
+  BLISP_ERR_NOT_IMPLEMENTED = -12,  // Non implemented function called
+  BLISP_ERR_API_ERROR = -13,        // Errors outside our control from api's we
+                              // integrate (Generally serial port/OS related)
 
 } blisp_return_t;
 #endif

--- a/lib/blisp.c
+++ b/lib/blisp.c
@@ -15,19 +15,20 @@
 
 static void drain(struct sp_port* port) {
 #if defined(__APPLE__) || defined(__FreeBSD__)
-    sp_drain(port);
+  sp_drain(port);
 #endif
 }
 
-int32_t blisp_device_init(struct blisp_device* device,
-                          struct blisp_chip* chip) {
+blisp_return_t blisp_device_init(struct blisp_device* device,
+                                 struct blisp_chip* chip) {
   device->chip = chip;
   device->is_usb = false;
-  return 0;
+  return BLISP_OK;
 }
 
-int32_t blisp_device_open(struct blisp_device* device, const char* port_name) {
-  int ret;
+blisp_return_t blisp_device_open(struct blisp_device* device,
+                                 const char* port_name) {
+  blisp_return_t ret;
   struct sp_port* serial_port = NULL;
 
   if (port_name != NULL) {
@@ -69,8 +70,7 @@ int32_t blisp_device_open(struct blisp_device* device, const char* port_name) {
   ret = sp_open(serial_port, SP_MODE_READ_WRITE);
   if (ret != SP_OK) {
     blisp_dlog("SP open failed: %d", ret);
-    return BLISP_ERR_UNKNOWN;  // TODO: Maybe this should be that it can't open
-                               // device?
+    return BLISP_ERR_CANT_OPEN_DEVICE;
   }
   // TODO: Handle errors in following functions, although, none of them *should*
   // fail
@@ -107,11 +107,11 @@ int32_t blisp_device_open(struct blisp_device* device, const char* port_name) {
   return BLISP_OK;
 }
 
-int32_t blisp_send_command(struct blisp_device* device,
-                           uint8_t command,
-                           void* payload,
-                           uint16_t payload_size,
-                           bool add_checksum) {
+blisp_return_t blisp_send_command(struct blisp_device* device,
+                                  uint8_t command,
+                                  void* payload,
+                                  uint16_t payload_size,
+                                  bool add_checksum) {
   int ret;
   struct sp_port* serial_port = device->serial_port;
 
@@ -141,8 +141,8 @@ int32_t blisp_send_command(struct blisp_device* device,
   return BLISP_OK;
 }
 
-int32_t blisp_receive_response(struct blisp_device* device,
-                               bool expect_payload) {
+blisp_return_t blisp_receive_response(struct blisp_device* device,
+                                      bool expect_payload) {
   // TODO: Check checksum
   int ret;
   struct sp_port* serial_port = device->serial_port;
@@ -174,7 +174,8 @@ int32_t blisp_receive_response(struct blisp_device* device,
   return BLISP_ERR_UNKNOWN;
 }
 
-int32_t blisp_device_handshake(struct blisp_device* device, bool in_ef_loader) {
+blisp_return_t blisp_device_handshake(struct blisp_device* device,
+                                      bool in_ef_loader) {
   int ret;
   uint8_t handshake_buffer[600];
   struct sp_port* serial_port = device->serial_port;
@@ -203,8 +204,8 @@ int32_t blisp_device_handshake(struct blisp_device* device, bool in_ef_loader) {
       }
     }
     ret = sp_blocking_write(serial_port, handshake_buffer, bytes_count, 500);
-	// not sure about Apple part, but FreeBSD needs it
-	drain(serial_port);
+    // not sure about Apple part, but FreeBSD needs it
+    drain(serial_port);
     if (ret < 0) {
       blisp_dlog("Handshake write failed, ret %d", ret);
       return BLISP_ERR_UNKNOWN;
@@ -221,15 +222,14 @@ int32_t blisp_device_handshake(struct blisp_device* device, bool in_ef_loader) {
         return BLISP_OK;
       }
     }
-
   }
   blisp_dlog("Received no response from chip.");
   return BLISP_ERR_NO_RESPONSE;
 }
 
-int32_t blisp_device_get_boot_info(struct blisp_device* device,
-                                   struct blisp_boot_info* boot_info) {
-  int ret;
+blisp_return_t blisp_device_get_boot_info(struct blisp_device* device,
+                                          struct blisp_boot_info* boot_info) {
+  blisp_return_t ret;
 
   ret = blisp_send_command(device, 0x10, NULL, 0, false);
   if (ret < 0)
@@ -240,7 +240,8 @@ int32_t blisp_device_get_boot_info(struct blisp_device* device,
     return ret;
 
   memcpy(boot_info->boot_rom_version, &device->rx_buffer[0],
-         4);  // TODO: Endianess
+         4);  // TODO: Endianess; this may break on big endian machines
+
   if (device->chip->type == BLISP_CHIP_BL70X) {
     memcpy(boot_info->chip_id, &device->rx_buffer[16], 8);
   }
@@ -249,9 +250,9 @@ int32_t blisp_device_get_boot_info(struct blisp_device* device,
 }
 
 // TODO: Use struct instead of uint8_t*
-int32_t blisp_device_load_boot_header(struct blisp_device* device,
-                                      uint8_t* boot_header) {
-  int ret;
+blisp_return_t blisp_device_load_boot_header(struct blisp_device* device,
+                                             uint8_t* boot_header) {
+  blisp_return_t ret;
   ret = blisp_send_command(device, 0x11, boot_header, 176, false);
   if (ret < 0)
     return ret;
@@ -262,10 +263,10 @@ int32_t blisp_device_load_boot_header(struct blisp_device* device,
   return BLISP_OK;
 }
 
-int32_t blisp_device_load_segment_header(
+blisp_return_t blisp_device_load_segment_header(
     struct blisp_device* device,
     struct blisp_segment_header* segment_header) {
-  int ret;
+  blisp_return_t ret;
   ret = blisp_send_command(device, 0x17, segment_header, 16, false);
   if (ret < 0)
     return ret;
@@ -276,10 +277,10 @@ int32_t blisp_device_load_segment_header(
   return BLISP_OK;
 }
 
-int32_t blisp_device_load_segment_data(struct blisp_device* device,
-                                       uint8_t* segment_data,
-                                       uint32_t segment_data_length) {
-  int ret;
+blisp_return_t blisp_device_load_segment_data(struct blisp_device* device,
+                                              uint8_t* segment_data,
+                                              uint32_t segment_data_length) {
+  blisp_return_t ret;
   ret = blisp_send_command(device, 0x18, segment_data, segment_data_length,
                            false);
   if (ret < 0)
@@ -291,8 +292,8 @@ int32_t blisp_device_load_segment_data(struct blisp_device* device,
   return BLISP_OK;
 }
 
-int32_t blisp_device_check_image(struct blisp_device* device) {
-  int ret;
+blisp_return_t blisp_device_check_image(struct blisp_device* device) {
+  blisp_return_t ret;
   ret = blisp_send_command(device, 0x19, NULL, 0, false);
   if (ret < 0)
     return ret;
@@ -303,11 +304,11 @@ int32_t blisp_device_check_image(struct blisp_device* device) {
   return BLISP_OK;
 }
 
-int32_t blisp_device_write_memory(struct blisp_device* device,
-                                  uint32_t address,
-                                  uint32_t value,
-                                  bool wait_for_res) {
-  int ret;
+blisp_return_t blisp_device_write_memory(struct blisp_device* device,
+                                         uint32_t address,
+                                         uint32_t value,
+                                         bool wait_for_res) {
+  blisp_return_t ret;
   uint8_t payload[8];
   *(uint32_t*)(payload) = address;
   *(uint32_t*)(payload + 4) = value;  // TODO: Endianness
@@ -323,8 +324,8 @@ int32_t blisp_device_write_memory(struct blisp_device* device,
   return BLISP_OK;
 }
 
-int32_t blisp_device_run_image(struct blisp_device* device) {
-  int ret;
+blisp_return_t blisp_device_run_image(struct blisp_device* device) {
+  blisp_return_t ret;
 
   if (device->chip->type == BLISP_CHIP_BL70X) {  // ERRATA
     ret = blisp_device_write_memory(device, 0x4000F100, 0x4E424845, true);
@@ -351,14 +352,14 @@ int32_t blisp_device_run_image(struct blisp_device* device) {
   return BLISP_OK;
 }
 
-int32_t blisp_device_flash_erase(struct blisp_device* device,
-                                 uint32_t start_address,
-                                 uint32_t end_address) {
+blisp_return_t blisp_device_flash_erase(struct blisp_device* device,
+                                        uint32_t start_address,
+                                        uint32_t end_address) {
   uint8_t payload[8];
   *(uint32_t*)(payload + 0) = start_address;
   *(uint32_t*)(payload + 4) = end_address;
 
-  int ret = blisp_send_command(device, 0x30, payload, 8, true);
+  blisp_return_t ret = blisp_send_command(device, 0x30, payload, 8, true);
   if (ret < 0)
     return ret;
   do {
@@ -368,17 +369,18 @@ int32_t blisp_device_flash_erase(struct blisp_device* device,
   return 0;
 }
 
-int32_t blisp_device_flash_write(struct blisp_device* device,
-                                 uint32_t start_address,
-                                 uint8_t* payload,
-                                 uint32_t payload_size) {
+blisp_return_t blisp_device_flash_write(struct blisp_device* device,
+                                        uint32_t start_address,
+                                        uint8_t* payload,
+                                        uint32_t payload_size) {
   // TODO: Add max payload size (8184?)
   // TODO: Don't use malloc + add check
 
   uint8_t* buffer = malloc(4 + payload_size);
   *((uint32_t*)(buffer)) = start_address;
   memcpy(buffer + 4, payload, payload_size);
-  int ret = blisp_send_command(device, 0x31, buffer, payload_size + 4, true);
+  blisp_return_t ret =
+      blisp_send_command(device, 0x31, buffer, payload_size + 4, true);
   if (ret < 0)
     goto exit1;
   ret = blisp_receive_response(device, false);
@@ -387,7 +389,7 @@ exit1:
   return ret;
 }
 
-int32_t blisp_device_program_check(struct blisp_device* device) {
+blisp_return_t blisp_device_program_check(struct blisp_device* device) {
   int ret = blisp_send_command(device, 0x3A, NULL, 0, true);
   if (ret < 0)
     return ret;
@@ -395,11 +397,11 @@ int32_t blisp_device_program_check(struct blisp_device* device) {
   if (ret < 0)
     return ret;
 
-  return 0;
+  return BLISP_OK;
 }
 
-int32_t blisp_device_reset(struct blisp_device* device) {
-  int ret = blisp_send_command(device, 0x21, NULL, 0, true);
+blisp_return_t blisp_device_reset(struct blisp_device* device) {
+  blisp_return_t ret = blisp_send_command(device, 0x21, NULL, 0, true);
   if (ret < 0)
     return ret;
   ret = blisp_receive_response(device, false);

--- a/tools/blisp/src/cmd.h
+++ b/tools/blisp/src/cmd.h
@@ -3,11 +3,11 @@
 #define BLISP_CMD_H
 
 #include <stdint.h>
-
+#include "error_codes.h"
 struct cmd {
   const char* name;
-  int8_t (*args_init)();
-  uint8_t (*args_parse_exec)(int argc, char** argv);
+  blisp_return_t (*args_init)();
+  blisp_return_t (*args_parse_exec)(int argc, char** argv);
   void (*args_print_syntax)();
   void (*args_free)();
 };

--- a/tools/blisp/src/cmd/iot.c
+++ b/tools/blisp/src/cmd/iot.c
@@ -1,7 +1,7 @@
+#include <argtable3.h>
 #include <blisp_easy.h>
 #include "../cmd.h"
 #include "../common.h"
-#include <argtable3.h>
 
 #define REG_EXTENDED 1
 #define REG_ICASE (REG_EXTENDED << 1)
@@ -9,21 +9,21 @@
 static struct arg_rex* cmd;
 static struct arg_file* single_download;
 static struct arg_int* single_download_location;
-static struct arg_str *port_name, *chip_type; // TODO: Make this common
+static struct arg_str *port_name, *chip_type;  // TODO: Make this common
 static struct arg_lit* reset;
 static struct arg_end* end;
 static void* cmd_iot_argtable[7];
 
-void blisp_single_download()
-{
+blisp_return_t blisp_single_download() {
   struct blisp_device device;
-  int32_t ret;
+  blisp_return_t ret;
 
-  if (blisp_common_init_device(&device, port_name, chip_type) != 0) {
-    return;
+  ret = blisp_common_init_device(&device, port_name, chip_type);
+  if (ret != BLISP_OK) {
+    return ret;
   }
-
-  if (blisp_common_prepare_flash(&device) != 0) {
+  ret = blisp_common_prepare_flash(&device);
+  if (ret != BLISP_OK) {
     // TODO: Error handling
     goto exit1;
   }
@@ -32,6 +32,7 @@ void blisp_single_download()
   if (data_file == NULL) {
     fprintf(stderr, "Failed to open data file \"%s\".\n",
             single_download->filename[0]);
+    ret = BLISP_ERR_CANT_OPEN_FILE;
     goto exit1;
   }
   fseek(data_file, 0, SEEK_END);
@@ -39,9 +40,9 @@ void blisp_single_download()
   rewind(data_file);
 
   printf("Erasing the area, this might take a while...\n");
-  ret =
-      blisp_device_flash_erase(&device, *single_download_location->ival,
-                               *single_download_location->ival + data_file_size + 1);
+  ret = blisp_device_flash_erase(
+      &device, *single_download_location->ival,
+      *single_download_location->ival + data_file_size + 1);
   if (ret != BLISP_OK) {
     fprintf(stderr, "Failed to erase.\n");
     goto exit2;
@@ -51,8 +52,8 @@ void blisp_single_download()
   struct blisp_easy_transport data_transport =
       blisp_easy_transport_new_from_file(data_file);
 
-  ret = blisp_easy_flash_write(&device, &data_transport, *single_download_location->ival,
-                               data_file_size,
+  ret = blisp_easy_flash_write(&device, &data_transport,
+                               *single_download_location->ival, data_file_size,
                                blisp_common_progress_callback);
   if (ret < BLISP_OK) {
     fprintf(stderr, "Failed to write data to flash.\n");
@@ -67,21 +68,28 @@ void blisp_single_download()
   }
   printf("Program OK!\n");
 
-  if (reset->count > 0) { // TODO: could be common
-    blisp_device_reset(&device);
+  if (reset->count > 0) {  // TODO: could be common
     printf("Resetting the chip.\n");
+    ret = blisp_device_reset(&device);
+    if (ret != BLISP_OK) {
+      fprintf(stderr, "Failed to reset chip.\n");
+      goto exit2;
+    }
   }
-
-  printf("Download complete!\n");
+  if (ret == BLISP_OK) {
+    printf("Download complete!\n");
+  }
 
 exit2:
   if (data_file != NULL)
     fclose(data_file);
 exit1:
   blisp_device_close(&device);
+
+  return ret;
 }
 
-int8_t cmd_iot_args_init() {
+blisp_return_t cmd_iot_args_init() {
   cmd_iot_argtable[0] = cmd =
       arg_rex1(NULL, NULL, "iot", NULL, REG_ICASE, NULL);
   cmd_iot_argtable[1] = chip_type =
@@ -99,9 +107,9 @@ int8_t cmd_iot_args_init() {
 
   if (arg_nullcheck(cmd_iot_argtable) != 0) {
     fprintf(stderr, "insufficient memory\n");
-    return -1;
+    return BLISP_ERR_OUT_OF_MEMORY;
   }
-  return 0;
+  return BLISP_OK;
 }
 
 void cmd_iot_args_print_glossary() {
@@ -111,20 +119,19 @@ void cmd_iot_args_print_glossary() {
   arg_print_glossary(stdout, cmd_iot_argtable, "  %-25s %s\n");
 }
 
-uint8_t cmd_iot_parse_exec(int argc, char** argv) {
+blisp_return_t cmd_iot_parse_exec(int argc, char** argv) {
   int errors = arg_parse(argc, argv, cmd_iot_argtable);
   if (errors == 0) {
     if (single_download->count == 1 && single_download_location->count == 1) {
-      blisp_single_download();
-      return 1;
+      return blisp_single_download();
     } else {
-      return 0;
+      return BLISP_ERR_INVALID_COMMAND;
     }
   } else if (cmd->count == 1) {
     cmd_iot_args_print_glossary();
-    return 1;
+    return BLISP_OK;
   }
-  return 0;
+  return BLISP_ERR_INVALID_COMMAND;
 }
 
 void cmd_iot_args_print_syntax() {
@@ -137,4 +144,4 @@ void cmd_iot_free() {
 }
 
 struct cmd cmd_iot = {"iot", cmd_iot_args_init, cmd_iot_parse_exec,
-                        cmd_iot_args_print_syntax, cmd_iot_free};
+                      cmd_iot_args_print_syntax, cmd_iot_free};

--- a/tools/blisp/src/cmd/write.c
+++ b/tools/blisp/src/cmd/write.c
@@ -249,7 +249,7 @@ exit1:
   blisp_device_close(&device);
 }
 
-int8_t cmd_write_args_init() {
+blisp_return_t cmd_write_args_init() {
   cmd_write_argtable[0] = cmd =
       arg_rex1(NULL, NULL, "write", NULL, REG_ICASE, NULL);
   cmd_write_argtable[1] = chip_type =
@@ -265,9 +265,9 @@ int8_t cmd_write_args_init() {
 
   if (arg_nullcheck(cmd_write_argtable) != 0) {
     fprintf(stderr, "insufficient memory\n");
-    return -1;
+    return BLISP_ERR_OUT_OF_MEMORY;
   }
-  return 0;
+  return BLISP_OK;
 }
 
 void cmd_write_args_print_glossary() {
@@ -277,16 +277,16 @@ void cmd_write_args_print_glossary() {
   arg_print_glossary(stdout, cmd_write_argtable, "  %-25s %s\n");
 }
 
-uint8_t cmd_write_parse_exec(int argc, char** argv) {
+blisp_return_t cmd_write_parse_exec(int argc, char** argv) {
   int errors = arg_parse(argc, argv, cmd_write_argtable);
   if (errors == 0) {
-    blisp_flash_firmware();  // TODO: Error code?
-    return 1;
+    return blisp_flash_firmware();  // TODO: Error code?
+
   } else if (cmd->count == 1) {
     cmd_write_args_print_glossary();
-    return 1;
+    return BLISP_OK;
   }
-  return 0;
+  return BLISP_ERR_INVALID_COMMAND;
 }
 
 void cmd_write_args_print_syntax() {

--- a/tools/blisp/src/cmd/write.c
+++ b/tools/blisp/src/cmd/write.c
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
+#include <argtable3.h>
 #include <blisp.h>
+#include <blisp_easy.h>
+#include <blisp_struct.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include "../cmd.h"
 #include "../common.h"
 #include "../util.h"
-#include <argtable3.h>
-#include <blisp_easy.h>
-#include <blisp_struct.h>
 
 #define REG_EXTENDED 1
 #define REG_ICASE (REG_EXTENDED << 1)
@@ -164,12 +164,13 @@ void fill_up_boot_header(struct bfl_boot_header* boot_header) {
   boot_header->crc32 = 0xDEADBEEF;
 }
 
-void blisp_flash_firmware() {
+blisp_return_t blisp_flash_firmware() {
   struct blisp_device device;
-  int32_t ret;
+  blisp_return_t ret;
+  ret = blisp_common_init_device(&device, port_name, chip_type);
 
-  if (blisp_common_init_device(&device, port_name, chip_type) != 0) {
-    return;
+  if (ret != 0) {
+    return ret;
   }
 
   if (blisp_common_prepare_flash(&device) != 0) {


### PR DESCRIPTION
Seeds more error code values into the code, and ensures that the CLI tool returns these as exit codes.

Not tested on hardware (yet).

Should close #29 when merged.