### PR TITLE
Build linux executables for multiple architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,3 +64,79 @@ jobs:
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error 
+
+  build-linux-alternative-arch:
+    runs-on: ubuntu-latest
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    # Run steps on a matrix of 4 arch/distro combinations
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu_latest
+          - arch: armv7
+            distro: ubuntu_latest
+          - arch: riscv64
+            distro: ubuntu_latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          # Create an artifacts directory
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+
+          # Mount the artifacts directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+
+          # Pass some environment variables to the container
+          env: | # YAML, but pipe character is necessary
+            artifact_name: blisp-${{ matrix.distro }}_${{ matrix.arch }}
+
+          # The shell to run commands with in the container
+          shell: /bin/sh
+
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster|bullseye)
+                apt-get update -q -y
+                apt-get install -q -y git cmake build-essential
+                ;;
+            esac
+
+          # Produce a binary artifact and place it in the mounted volume
+          run: |
+            git submodule update --init --recursive
+            mkdir build
+            cd build
+            cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
+            cmake --build .
+            ls -lah build/tools/blisp/
+            cp build/tools/blisp/blisp "/artifacts/${artifact_name}"
+            echo "Produced artifact at /artifacts/${artifact_name}"
+
+      - name: Show the artifact
+        # Items placed in /artifacts in the container will be in
+        # ${PWD}/artifacts on the host.
+        run: |
+          ls -al "${PWD}/artifacts"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            build/tools/blisp/*
+          if-no-files-found: error 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
           # Pass some environment variables to the container
           env: | # YAML, but pipe character is necessary
-            artifact_name: blisp-${{ matrix.distro }}_${{ matrix.arch }}
+            artifact_name: blisp-linux-${{ matrix.arch }}
 
           # The shell to run commands with in the container
           shell: /bin/sh
@@ -128,20 +128,14 @@ jobs:
             mkdir build
             cd build
             cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
-            cmake --build .
-            ls -lah build/tools/blisp/
-            cp build/tools/blisp/blisp "/artifacts/${artifact_name}"
+            cmake --build . -j2
+            cp ./tools/blisp/blisp "/artifacts/${artifact_name}"
             echo "Produced artifact at /artifacts/${artifact_name}"
-
-      - name: Show the artifact
-        # Items placed in /artifacts in the container will be in
-        # ${PWD}/artifacts on the host.
-        run: |
-          ls -al "${PWD}/artifacts"
 
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
+          name: blisp-linux-${{ matrix.arch }}
           path: |
-            build/tools/blisp/*
+            artifacts/blisp-*
           if-no-files-found: error 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp Windows x64 build
           path: |
@@ -40,7 +40,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build .
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp macOS x64 build
           path: |
@@ -61,7 +61,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build .
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp Linux x64 build
           path: |
@@ -133,7 +133,7 @@ jobs:
             echo "Produced artifact at /artifacts/${artifact_name}"
 
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: blisp-linux-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,12 @@ jobs:
       run:
         shell: cmd
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: lukka/get-cmake@latest
       - name: Build blisp tool
         run: |
-          git submodule update --init --recursive
           mkdir build
           cd build
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
@@ -28,11 +29,12 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: lukka/get-cmake@latest
       - name: Build blisp tool
         run: |
-          git submodule update --init --recursive
           mkdir build
           cd build
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
@@ -48,11 +50,12 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: lukka/get-cmake@latest
       - name: Build blisp tool
         run: |
-          git submodule update --init --recursive
           mkdir build
           cd build
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
@@ -81,6 +84,8 @@ jobs:
             distro: ubuntu_latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - uses: uraimo/run-on-arch-action@v2
         name: Build artifact
         id: build
@@ -119,7 +124,7 @@ jobs:
 
           # Produce a binary artifact and place it in the mounted volume
           run: |
-            git submodule update --init --recursive
+            git config --global --add safe.directory /home/runner/work/blisp/blisp
             mkdir build
             cd build
             cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp Windows x64 build
+          name: blips-windows-x86_64.zip
           path: |
             build/tools/blisp/Release/blisp.exe
           if-no-files-found: error
@@ -42,7 +42,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp macOS x64 build
+          name: blips-apple-x86_64.zip
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error
@@ -63,7 +63,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp Linux x64 build
+          name: blips-linux-x86_64.zip
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error 
@@ -135,7 +135,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blisp-linux-${{ matrix.arch }}
+          name: blisp-linux-${{ matrix.arch }}.zip
           path: |
             artifacts/blisp-*
           if-no-files-found: error 


### PR DESCRIPTION
This adds a new CI option that builds binary files for Ubuntu for the other main architectures (riscv, aarch64, armv7).
This does slow down CI a little but not dramatically.