### PR TITLE
Use CMAKE_INSTALL_LIBDIR for install destination to respect build forges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,11 @@ else()
     endif()
 endif()
 
-install(TARGETS libblisp libblisp_static DESTINATION lib)
+install(TARGETS libblisp libblisp_static 
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
 if(BLISP_BUILD_CLI)
     add_subdirectory(tools/blisp)


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR should be popualted with either lib or lib64,
depending on the architecture. This change makes it so that this flag is
respected by blisp and the library, runtime, and archives are installed
to the location requested by the build.
