### PR TITLE
Compile internal file_parsers lib always statically

### DIFF
--- a/tools/blisp/src/file_parsers/CMakeLists.txt
+++ b/tools/blisp/src/file_parsers/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB_RECURSE sources
 )
 list(APPEND ADD_SRCS  ${sources})
 
-add_library(file_parsers 
+add_library(file_parsers STATIC
 "${CMAKE_CURRENT_SOURCE_DIR}/bin/bin_file.c"
 "${CMAKE_CURRENT_SOURCE_DIR}/dfu/dfu_file.c"
 "${CMAKE_CURRENT_SOURCE_DIR}/dfu/dfu_crc.c"


### PR DESCRIPTION
Otherwise, depending on BUILD_SHARED_LIBS default, it may be compiled dynamically. However, the resulting DSO currently would not be installed, resulting in unusable installed blisp binary.