### PR TITLE
Enable macOS universal builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: blips-apple-x86_64.zip
+          name: blips-apple-universal.zip
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
 project(blisp C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 11)

--- a/README.md
+++ b/README.md
@@ -94,3 +94,20 @@ Because this is done at the lowest level of serial communication, the
 displays aren't packet-aware or know about the chip's command set or such.
 This is really only useful for debugging systems-level issues withing
 the device or blisp itself.
+
+## Troubleshooting
+
+### macOS
+
+Depending on your current system security settings, modern versions of macOS requires all software to be notarised before you are able to execute it. This is specially true for software that is downloaded directly from the internet.
+
+If that is the case, you will get an error that looks like the following:
+> **“blisp” cannot be opened because the developer cannot be verified.**
+>
+> macOS cannot verify that this app is free from malware.
+
+In that case, you will need to remove the *quarantine* flag that macOS adds to the executable. After that you should be able to run **blisp** as normal.
+
+```bash
+xattr -d com.apple.quarantine blisp
+```


### PR DESCRIPTION
This PR enables universal binaries for the macOS build. This way you are able to run **blisp** on newer machines, without having to rely on Rosetta 2.

The change is quite simple, since CMake already exposes a variable that provided such [functionality][1].

This PR sets the **CMAKE_OSX_ARCHITECTURES** to enable both *x86_64* and *arm64* builds on a single binary. This options is already ignored for the remaining platforms, so we don't need to conditionally set it.

Alternatively we can also manually provide this setting via the command line. That way we can keep the legacy build running as it is, and create a separate build job that outputs a universal artefact. But fat binaries are well supported on all versions of macOS, so I don't think such options is needed.

[1]: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html