### PR TITLE
blisp_struct.h: use _Static_assert for pre-C23 compatibility

### DIFF
--- a/include/blisp_struct.h
+++ b/include/blisp_struct.h
@@ -9,6 +9,12 @@
 #include <assert.h>
 #include <stdint.h>
 
+#if !defined(static_assert) && (defined(__GNUC__) || defined(__clang__)) \
+    && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+    && __STDC_VERSION__ <= 201710L
+#define static_assert _Static_assert
+#endif
+
 #pragma pack(push, 1)
 
 typedef struct {


### PR DESCRIPTION
Closes: https://github.com/pine64/blisp/issues/61