### PR TITLE
feat: Add Nix flake & derivation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,22 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  check-nix-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - name: Check Nix Flake
+        run: nix flake check --print-build-logs
+
+  check-nix-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - name: Build package
+        run: nix build --print-build-logs
+
   build-windows:
     runs-on: windows-2022
     defaults:

--- a/blisp.nix
+++ b/blisp.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  self,
+  stdenv,
+  fetchFromGitHub,
+  argtable,
+  cmake,
+  libserialport,
+  pkg-config,
+  testers,
+  IOKit ? null,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blisp";
+  version = "0.0.4-unstable";
+  src = self;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    argtable
+    libserialport
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin IOKit;
+
+  cmakeFlags = [
+    "-DBLISP_BUILD_CLI=ON"
+    "-DBLISP_USE_SYSTEM_LIBRARIES=ON"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-error=implicit-function-declaration";
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = with lib; {
+    description = "In-System-Programming (ISP) tool & library for Bouffalo Labs RISC-V Microcontrollers and SoCs";
+    license = licenses.mit;
+    mainProgram = "blisp";
+    homepage = "https://github.com/pine64/blisp";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.bdd ];
+  };
+})

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }@inputs:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forEachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        with pkgs;
+        {
+          blisp = callPackage ./blisp.nix { inherit self; };
+          default = self.packages.${system}.blisp;
+        }
+      );
+
+      devShells = forEachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        with pkgs;
+        {
+          default = mkShell {
+            name = "blisp-dev";
+            nativeBuildInputs = [ self.packages.${system}.default ];
+          };
+        }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
This adds a Nix flake, shims for 'legacy' Nix, and a `.envrc` for
`direnv`. blisp is now able to run directly via:

`nix run github:pine64/blisp`

and for Nix/NixOS users, this helps with a one-click developer
environment.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
