### PR TITLE
fix: Make blisp check for existing file before flashing

### DIFF
--- a/tools/blisp/src/cmd.h
+++ b/tools/blisp/src/cmd.h
@@ -2,6 +2,14 @@
 #ifndef BLISP_CMD_H
 #define BLISP_CMD_H
 
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#include <unistd.h>
+#elif defined(_WIN32) || defined(WIN32) 
+#include <io.h>
+#define R_OK 4
+#define access _access
+#endif
+
 #include <stdint.h>
 #include "error_codes.h"
 struct cmd {

--- a/tools/blisp/src/cmd/iot.c
+++ b/tools/blisp/src/cmd/iot.c
@@ -13,10 +13,19 @@ static struct arg_str *port_name, *chip_type;  // TODO: Make this common
 static struct arg_lit* reset;
 static struct arg_end* end;
 static void* cmd_iot_argtable[7];
+static void cmd_iot_args_print_glossary();
 
 blisp_return_t blisp_single_download() {
   struct blisp_device device;
   blisp_return_t ret;
+
+  if (access(single_download->filename[0], R_OK) != 0) {
+    // File not accessible, error out.
+    fprintf(stderr, "Input firmware not found: %s\n", single_download->filename[0]);
+    cmd_iot_args_print_glossary(); /* Print help to assist user */
+    /* No need to free memory, will now exit with ret code 1 */
+    return 1;
+  }
 
   ret = blisp_common_init_device(&device, port_name, chip_type);
   if (ret != BLISP_OK) {

--- a/tools/blisp/src/cmd/write.c
+++ b/tools/blisp/src/cmd/write.c
@@ -20,6 +20,7 @@ static struct arg_str *port_name, *chip_type;
 static struct arg_lit* reset;
 static struct arg_end* end;
 static void* cmd_write_argtable[6];
+static void cmd_write_args_print_glossary();
 
 void fill_up_boot_header(struct bfl_boot_header* boot_header) {
   memcpy(boot_header->magiccode, "BFNP", 4);
@@ -168,6 +169,15 @@ void fill_up_boot_header(struct bfl_boot_header* boot_header) {
 blisp_return_t blisp_flash_firmware() {
   struct blisp_device device;
   blisp_return_t ret;
+
+  if (access(binary_to_write->filename[0], R_OK) != 0) {
+    // File not accessible, error out.
+    fprintf(stderr, "Input firmware not found: %s\n", binary_to_write->filename[0]);
+    cmd_write_args_print_glossary(); /* Print help to assist user */
+    /* No need to free memory, will now exit with ret code 1 */
+    return 1;
+  }
+
   ret = blisp_common_init_device(&device, port_name, chip_type);
 
   if (ret != 0) {
@@ -178,6 +188,7 @@ blisp_return_t blisp_flash_firmware() {
     // TODO: Error handling
     goto exit1;
   }
+
   parsed_firmware_file_t parsed_file;
   memset(&parsed_file, 0, sizeof(parsed_file));
   int parsed_result =


### PR DESCRIPTION
This commit adds a simple check to both blisp commands that checks the
passed firmware .bin file exists, and is readable.

Justification: I flashed my Pinecil V2 that arrived today, and
misspelled the filename. blisp erased flash, and then exited - it did
not check the firmware .bin was readable/accessible, which meant my
Pinecil was soft-bricked.

I have tested the change, and it works for both commands when the input
file isn't readable.

I had to declare the `cmd_{iot,write}_args_print_glossary` function as
static before the call, so that we don't use undeclared functions before
we call them.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
