### PR TITLE
Update to v4 GitHub Actions checkout and upload-artifact since v3 is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: cmd
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: lukka/get-cmake@latest
@@ -45,7 +45,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: lukka/get-cmake@latest
@@ -66,7 +66,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: lukka/get-cmake@latest
@@ -99,7 +99,7 @@ jobs:
           - arch: riscv64
             distro: ubuntu_latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: blips-windows-x86_64.zip
           path: |
@@ -56,7 +56,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build .
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: blips-apple-universal.zip
           path: |
@@ -77,7 +77,7 @@ jobs:
           cmake .. -DBLISP_BUILD_CLI=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build .
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: blips-linux-x86_64.zip
           path: |
@@ -149,7 +149,7 @@ jobs:
             echo "Produced artifact at /artifacts/${artifact_name}"
 
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: blisp-linux-${{ matrix.arch }}.zip
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           name: blips-linux-x86_64.zip
           path: |
             build/tools/blisp/blisp
-          if-no-files-found: error 
+          if-no-files-found: error
 
   build-linux-alternative-arch:
     runs-on: ubuntu-latest
@@ -154,4 +154,4 @@ jobs:
           name: blisp-linux-${{ matrix.arch }}.zip
           path: |
             artifacts/blisp-*
-          if-no-files-found: error 
+          if-no-files-found: error


### PR DESCRIPTION
Hello. In short, _"Actions"_ tab [gives the following warning](https://github.com/pine64/blisp/actions/runs/12115420526):
```
Deprecation notice: v1, v2, and v3 of the artifact actions
The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "blips-apple-universal.zip", "blips-linux-x86_64.zip", "blips-windows-x86_64.zip", "blisp-linux-aarch64.zip", "blisp-linux-armv7.zip", "blisp-linux-riscv64.zip".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

Therefore, this tiny patch switches _GitHub Actions_ to the latest v4. I did enable _Actions_ in my forked version of this repo, made builds, and checked the produced `zips` with this patch: [the zips themselves and the content structured in the same way](https://github.com/ia/blisp/actions/runs/12129881604#artifacts).

P.S. It's nice to see some familiar faces here :) The thing is that I may need to use this tool soon, so I decided to check _"what's what"_ and how _Pinecil v2_ can be flashed, but I forgot that since it doesn't have _DFU_, this separate tool must be used. So, eventually I started to look around and see if I may be useful in any way around here as well. ;)