### PR TITLE
workflows/build.yml: remove redundant zip extension from file names of artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: blips-windows-x86_64.zip
+          name: blips-windows-x86_64
           path: |
             build/tools/blisp/Release/blisp.exe
           if-no-files-found: error
@@ -58,7 +58,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: blips-apple-universal.zip
+          name: blips-apple-universal
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error
@@ -79,7 +79,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: blips-linux-x86_64.zip
+          name: blips-linux-x86_64
           path: |
             build/tools/blisp/blisp
           if-no-files-found: error
@@ -151,7 +151,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: blisp-linux-${{ matrix.arch }}.zip
+          name: blisp-linux-${{ matrix.arch }}
           path: |
             artifacts/blisp-*
           if-no-files-found: error


### PR DESCRIPTION
To: @Ralim
CC: @gamelaster

Hello. Just another one little improvement.

Current behavior: when downloading artifacts, they all have excessive `.zip` extension in file names which looks a little bit strange and confusing (like it's a twice zipped file), i.e. `blips-linux-x86_64.zip.zip` from [here](https://github.com/pine64/blisp/actions/runs/12288448714#artifacts). It happens because _GitHub_ Actions already append `.zip` automagically.

Proposed behavior: remove redundant zip extension from file names of artifacts. With this change files will be having [only one `zip` extension](https://github.com/ia/blisp/actions/runs/12307132684#artifacts).

I hope this won't break anyone's workflow. Let me know what you think.