### PR TITLE
Makefile: add file with basic targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+#!/usr/bin/env make -f
+
+### global variables section
+
+# static vars
+BUILD_DIR:="build"
+BUILD_BIN:="$(BUILD_DIR)/tools/blisp/blisp"
+
+# dynamic vars
+FILES_CMAKE:=$(shell find  .  -path ./$(BUILD_DIR) -prune -false  -o  -type f  -name '*.cmake'  -o  -type f  -name 'CMakeLists.txt')
+FILES_SRC:=$(shell   find  .  -path ./$(BUILD_DIR) -prune -false  -o  -type f  -name '*.c'      -o  -type f  -name '*.h')
+
+### main targets section
+
+# simplify build
+build:  $(FILES_CMAKE)  $(FILES_SRC)  Makefile
+	@echo "\n>>>> Generating build files in: $(BUILD_DIR) ...\n"
+	@cmake  -S .  -B $(BUILD_DIR)  -DBLISP_BUILD_CLI=ON
+	@echo "\n>>>> Building...\n"
+	@cmake  --build  $(BUILD_DIR)
+	@echo "\n>>>> DONE: $(BUILD_BIN)\n"
+
+# deleting output build directory with its content
+clean:
+	-@rm -rf $(BUILD_DIR)/
+
+# printf-like debug target
+vars:
+	@echo "\n>>>> FILES_CMAKE:"
+	@echo "$(FILES_CMAKE)" | sed 's, ,\n,g'
+	@echo "\n>>>> FILES_SRC:"
+	@echo "$(FILES_SRC)" | sed 's, ,\n,g'
+
+.PHONY: clean  vars
+


### PR DESCRIPTION
TO: @Ralim
CC: @gamelaster

Hello!
TL;DR: add a basic `Makefile` (for a start) to simplify `cmake` build process of `blisp`.

---

As [advanced] user, I get used to _"fire'n'forget"_ commands to build 3rd party open source software, i.e. `./build.sh`/`make`/etc. I understand some advantages of `cmake`. Although even official documentation to build `blisp` contains a few commands (`mkdir build; cd build; cmake ...`), which a user should type/copy'paste. This `Makefile` simplify a process as easy as `$ make`. I understand the irony of adding `GNUMake` build file in the project using `CMake` already, but I noticed that there are already some configs & build files for 3rd party systems/distros (like `nix`), so I hope that one more small build file won't hurt anybody.

If you find it worthwhile, I will obligate myself to try as hard as I can to maintain & support this `Makefile` in the future (including verification & porting to be compatible with other *NIX systems like _FreeBSD_ and _macOS_), and fixing any issues (since _probably_ there are some anyway).

Let me know, what you think!

I tested it briefly in _Ubuntu 24.04_, and _it seems_ that basic functions work as they should:

```
root@b2c2b3a25d10:/build/data# make

>>>> Generating build files in: build ...

-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /build/data/build

>>>> Building...

gmake[1]: Entering directory '/build/data/build'
gmake[2]: Entering directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[  2%] Building C object CMakeFiles/libblisp_obj.dir/lib/blisp.c.o
[  5%] Building C object CMakeFiles/libblisp_obj.dir/lib/chip/blisp_chip_bl60x.c.o
[  7%] Building C object CMakeFiles/libblisp_obj.dir/lib/chip/blisp_chip_bl70x.c.o
[ 10%] Building C object CMakeFiles/libblisp_obj.dir/lib/blisp_easy.c.o
[ 13%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/serialport.c.o
[ 15%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/timing.c.o
[ 18%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/linux.c.o
[ 21%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/linux_termios.c.o
gmake[3]: Leaving directory '/build/data/build'
[ 21%] Built target libblisp_obj
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 23%] Linking C shared library shared/libblisp.so
gmake[3]: Leaving directory '/build/data/build'
[ 23%] Built target libblisp
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 26%] Linking C static library static/libblisp.a
gmake[3]: Leaving directory '/build/data/build'
[ 26%] Built target libblisp_static
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 28%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_cmd.c.o
[ 31%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_date.c.o
[ 34%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_dbl.c.o
[ 36%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_dstr.c.o
[ 39%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_end.c.o
[ 42%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_file.c.o
[ 44%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_hashtable.c.o
[ 47%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_int.c.o
[ 50%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_lit.c.o
[ 52%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_rem.c.o
[ 55%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_rex.c.o
[ 57%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_str.c.o
[ 60%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_utils.c.o
[ 63%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/argtable3.c.o
[ 65%] Building C object tools/blisp/argtable3/src/CMakeFiles/argtable3.dir/arg_getopt_long.c.o
[ 68%] Linking C static library libargtable3_static.a
gmake[3]: Leaving directory '/build/data/build'
[ 68%] Built target argtable3
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 71%] Building C object tools/blisp/src/file_parsers/CMakeFiles/file_parsers.dir/bin/bin_file.c.o
[ 73%] Building C object tools/blisp/src/file_parsers/CMakeFiles/file_parsers.dir/dfu/dfu_file.c.o
[ 76%] Building C object tools/blisp/src/file_parsers/CMakeFiles/file_parsers.dir/dfu/dfu_crc.c.o
[ 78%] Building C object tools/blisp/src/file_parsers/CMakeFiles/file_parsers.dir/parse_file.c.o
[ 81%] Building C object tools/blisp/src/file_parsers/CMakeFiles/file_parsers.dir/get_file_contents.c.o
[ 84%] Linking C static library libfile_parsers.a
gmake[3]: Leaving directory '/build/data/build'
[ 84%] Built target file_parsers
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 86%] Building C object tools/blisp/CMakeFiles/blisp.dir/src/main.c.o
[ 89%] Building C object tools/blisp/CMakeFiles/blisp.dir/src/cmd/write.c.o
[ 92%] Building C object tools/blisp/CMakeFiles/blisp.dir/src/util.c.o
[ 94%] Building C object tools/blisp/CMakeFiles/blisp.dir/src/common.c.o
[ 97%] Building C object tools/blisp/CMakeFiles/blisp.dir/src/cmd/iot.c.o
[100%] Linking C executable blisp
gmake[3]: Leaving directory '/build/data/build'
[100%] Built target blisp
gmake[2]: Leaving directory '/build/data/build'
gmake[1]: Leaving directory '/build/data/build'

>>>> DONE: build/tools/blisp/blisp

root@b2c2b3a25d10:/build/data# make
make: 'build' is up to date.
root@b2c2b3a25d10:/build/data# touch lib/
blisp.c       blisp_easy.c  chip/         
root@b2c2b3a25d10:/build/data# touch lib/blisp.c 
root@b2c2b3a25d10:/build/data# make

>>>> Generating build files in: build ...

-- Configuring done
-- Generating done
-- Build files have been written to: /build/data/build

>>>> Building...

gmake[1]: Entering directory '/build/data/build'
gmake[2]: Entering directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
Consolidate compiler generated dependencies of target libblisp_obj
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[  2%] Building C object CMakeFiles/libblisp_obj.dir/lib/blisp.c.o
[  5%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/serialport.c.o
[  7%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/timing.c.o
[ 10%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/linux.c.o
[ 13%] Building C object CMakeFiles/libblisp_obj.dir/vendor/libserialport/linux_termios.c.o
gmake[3]: Leaving directory '/build/data/build'
[ 21%] Built target libblisp_obj
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 23%] Linking C shared library shared/libblisp.so
gmake[3]: Leaving directory '/build/data/build'
[ 23%] Built target libblisp
gmake[3]: Entering directory '/build/data/build'
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 26%] Linking C static library static/libblisp.a
gmake[3]: Leaving directory '/build/data/build'
[ 26%] Built target libblisp_static
gmake[3]: Entering directory '/build/data/build'
Consolidate compiler generated dependencies of target argtable3
gmake[3]: Leaving directory '/build/data/build'
[ 68%] Built target argtable3
gmake[3]: Entering directory '/build/data/build'
Consolidate compiler generated dependencies of target file_parsers
gmake[3]: Leaving directory '/build/data/build'
[ 84%] Built target file_parsers
gmake[3]: Entering directory '/build/data/build'
Consolidate compiler generated dependencies of target blisp
gmake[3]: Leaving directory '/build/data/build'
gmake[3]: Entering directory '/build/data/build'
[ 86%] Linking C executable blisp
gmake[3]: Leaving directory '/build/data/build'
[100%] Built target blisp
gmake[2]: Leaving directory '/build/data/build'
gmake[1]: Leaving directory '/build/data/build'

>>>> DONE: build/tools/blisp/blisp

root@b2c2b3a25d10:/build/data# make clean
root@b2c2b3a25d10:/build/data# 
```
