### PR TITLE
util.c: add missing header, fixes macOS build

### DIFF
--- a/tools/blisp/src/util.c
+++ b/tools/blisp/src/util.c
@@ -10,6 +10,7 @@
 // to free an allocated buffer on the caller.nn
 
 #include <stdlib.h>
+#include <mach-o/dyld.h>
 
 static void util_get_executable_path(char* buffer_out, uint32_t max_size) {
   assert(max_size >= PATH_MAX);  // n.b. 1024 on MacOS. 4K on most Linux.


### PR DESCRIPTION
See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dyld.3.html